### PR TITLE
Add `VideoFetcher` and `VideoSlugExtractor` services with tests

### DIFF
--- a/.tasks/add-find-video-id/plan-video-fetcher-slug-extractor.md
+++ b/.tasks/add-find-video-id/plan-video-fetcher-slug-extractor.md
@@ -1,0 +1,180 @@
+# Plan: VideoFetcher + VideoSlugExtractor services
+
+## Context
+
+The SDK needs two new services to help consumers find videos by human-readable attributes:
+1. **`VideoFetcher`** — search videos by title or by video slug, returning `VideoDTO[]` with auto-pagination.
+2. **`VideoSlugExtractor`** — extract a video slug from an HLS link, embed code, or a `VideoDTO`.
+
+A "video slug" is the short ID embedded in kinescope.io URLs:
+- HLS link: `https://kinescope.io/wDXNmhxAhnJeRtNjAVChzS/master.m3u8` → `wDXNmhxAhnJeRtNjAVChzS`
+- Embed code: `<iframe src="https://kinescope.io/embed/wDXNmhxAhnJeRtNjAVChzS" ...>` → `wDXNmhxAhnJeRtNjAVChzS`
+
+## Files to Create
+
+| Path | Action |
+|------|--------|
+| `src/Services/Videos/VideoSlugExtractor.php` | Create — pure extraction logic, no deps |
+| `src/Services/Videos/VideoFetcher.php` | Create — wraps `Videos`, auto-paginated search |
+| `tests/Unit/Services/Videos/VideoSlugExtractorTest.php` | Create — pure unit tests |
+| `tests/Unit/Services/Videos/VideoFetcherTest.php` | Create — stub `ApiClientInterface` → `Videos` → `VideoFetcher` |
+
+No `composer.json` changes needed — no new dependencies.
+
+## Implementation
+
+### `src/Services/Videos/VideoSlugExtractor.php`
+
+Pure stateless service — no constructor, no dependencies.
+
+```php
+<?php
+declare(strict_types=1);
+namespace Kinescope\Services\Videos;
+
+use Kinescope\DTO\Video\VideoDTO;
+
+final class VideoSlugExtractor
+{
+    /** Extracts slug from HLS link, e.g. https://kinescope.io/{slug}/master.m3u8 */
+    public function fromHlsLink(string $hlsLink): ?string
+    {
+        if (preg_match('~kinescope\.io/([^/]+)/master\.m3u8~', $hlsLink, $m)) {
+            return $m[1];
+        }
+        return null;
+    }
+
+    /** Extracts slug from embed code, e.g. <iframe src="https://kinescope.io/embed/{slug}" ...> */
+    public function fromEmbedCode(string $embedCode): ?string
+    {
+        if (preg_match('~kinescope\.io/embed/([^"\'\\s/]+)~', $embedCode, $m)) {
+            return $m[1];
+        }
+        return null;
+    }
+
+    /** Tries hlsLink first, then embedCode. Returns null if neither is present/parseable. */
+    public function fromVideoDTO(VideoDTO $video): ?string
+    {
+        if ($video->hlsLink !== null) {
+            $slug = $this->fromHlsLink($video->hlsLink);
+            if ($slug !== null) {
+                return $slug;
+            }
+        }
+        if ($video->embedCode !== null) {
+            return $this->fromEmbedCode($video->embedCode);
+        }
+        return null;
+    }
+}
+```
+
+---
+
+### `src/Services/Videos/VideoFetcher.php`
+
+Takes `Videos` as constructor dependency (same pattern as `VideoDownloader`).
+Uses `Pagination::MAX_PER_PAGE` (100) for efficient bulk fetching.
+
+```php
+<?php
+declare(strict_types=1);
+namespace Kinescope\Services\Videos;
+
+use Kinescope\Core\Pagination;
+use Kinescope\DTO\Video\VideoDTO;
+
+final class VideoFetcher
+{
+    public function __construct(
+        private readonly Videos $videos,
+        private readonly VideoSlugExtractor $slugExtractor = new VideoSlugExtractor(),
+    ) {}
+
+    /**
+     * Find all videos whose title matches the search query (server-side, paginated).
+     * Uses Videos::search() which calls the dedicated /v1/videos/search endpoint.
+     *
+     * @return VideoDTO[]
+     */
+    public function findByTitle(string $title): array
+    {
+        $pagination = Pagination::firstPage(perPage: Pagination::MAX_PER_PAGE);
+        $results = [];
+
+        do {
+            $page = $this->videos->search($title, $pagination);
+            $results = array_merge($results, $page->getData());
+            $pagination = $pagination->nextPage();
+        } while ($page->hasNextPage());
+
+        return $results;
+    }
+
+    /**
+     * Find all videos whose slug matches (client-side filter, full list paginated).
+     * Paginates through Videos::list() and filters by extracted slug.
+     *
+     * @return VideoDTO[]
+     */
+    public function findByVideoSlug(string $slug): array
+    {
+        $pagination = Pagination::firstPage(perPage: Pagination::MAX_PER_PAGE);
+        $results = [];
+
+        do {
+            $page = $this->videos->list($pagination);
+            foreach ($page->getData() as $video) {
+                if ($this->slugExtractor->fromVideoDTO($video) === $slug) {
+                    $results[] = $video;
+                }
+            }
+            $pagination = $pagination->nextPage();
+        } while ($page->hasNextPage());
+
+        return $results;
+    }
+}
+```
+
+---
+
+### `tests/Unit/Services/Videos/VideoSlugExtractorTest.php`
+
+Pure unit tests — no mocks. Cover all three methods with:
+- Valid input → correct slug
+- Invalid/unrelated URL → null
+- `fromVideoDTO` priority: hlsLink first, fallback to embedCode, null if both absent
+
+---
+
+### `tests/Unit/Services/Videos/VideoFetcherTest.php`
+
+Follow pattern from `VideoDownloaderEventTest.php`:
+- Create anonymous class implementing `ApiClientInterface` as stub
+- Pass stub into real `Videos` instance
+- Pass `Videos` into `VideoFetcher`
+
+Scenarios:
+- `findByTitle` single page: stub returns 1 page with matching videos, no next page
+- `findByTitle` multi-page: stub returns 2 pages, verifies both pages merged
+- `findByVideoSlug` single page: stub returns videos, one matches slug
+- `findByVideoSlug` no match: stub returns videos, none match slug → empty array
+
+## Key Reused Existing Code
+
+- `Kinescope\Services\Videos\Videos::search()` — `src/Services/Videos/Videos.php`
+- `Kinescope\Services\Videos\Videos::list()` — `src/Services/Videos/Videos.php`
+- `Kinescope\Core\Pagination::firstPage()` / `nextPage()` — `src/Core/Pagination.php`
+- `Kinescope\DTO\Common\PaginatedResponse::hasNextPage()` / `getData()` — `src/DTO/Common/PaginatedResponse.php`
+- `Kinescope\DTO\Video\VideoDTO::$hlsLink` / `$embedCode` — `src/DTO/Video/VideoDTO.php`
+- `Kinescope\Contracts\ApiClientInterface` — `src/Contracts/ApiClientInterface.php`
+
+## Verification
+
+```bash
+make test-unit                          # run all unit tests including new ones
+make lint-all                           # PHPStan + CS-Fixer + Rector
+```

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 ## [0.4.0] - Unreleased
 
 ### Added
+- `VideoSlugExtractor` — pure stateless service for extracting video slugs from HLS links, embed codes, or `VideoDTO`.
+- `VideoFetcher` — auto-paginated search service:
+  - `findByTitle(string $title): VideoDTO[]` — server-side search via `Videos::search()`, iterates all pages.
+  - `findByVideoSlug(string $slug): VideoDTO[]` — client-side filter via `Videos::list()`, iterates all pages and matches by slug.
 - CLI application `bin/console` based on Symfony Console 8.
 - Command `video:info <video-id>` — fetches video data by UUID and outputs it as pretty-printed JSON to STDOUT.
   - API key resolved from `KINESCOPE_API_KEY` env variable or `--api-key` / `-k` option.

--- a/src/Services/Videos/VideoFetcher.php
+++ b/src/Services/Videos/VideoFetcher.php
@@ -1,0 +1,60 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Kinescope\Services\Videos;
+
+use Kinescope\Core\Pagination;
+use Kinescope\DTO\Video\VideoDTO;
+
+final class VideoFetcher
+{
+    public function __construct(
+        private readonly Videos $videos,
+        private readonly VideoSlugExtractor $slugExtractor = new VideoSlugExtractor(),
+    ) {
+    }
+
+    /**
+     * Find all videos whose title matches the search query (server-side, paginated).
+     *
+     * @return VideoDTO[]
+     */
+    public function findByTitle(string $title): array
+    {
+        $pagination = Pagination::firstPage(perPage: Pagination::MAX_PER_PAGE);
+        $results = [];
+
+        do {
+            $page = $this->videos->search($title, $pagination);
+            $results = array_merge($results, $page->getData());
+            $pagination = $pagination->nextPage();
+        } while ($page->hasNextPage());
+
+        return $results;
+    }
+
+    /**
+     * Find all videos whose slug matches (client-side filter, full list paginated).
+     *
+     * @return VideoDTO[]
+     */
+    public function findByVideoSlug(string $slug): array
+    {
+        $pagination = Pagination::firstPage(perPage: Pagination::MAX_PER_PAGE);
+        $results = [];
+
+        do {
+            $page = $this->videos->list($pagination);
+
+            foreach ($page->getData() as $video) {
+                if ($this->slugExtractor->fromVideoDTO($video) === $slug) {
+                    $results[] = $video;
+                }
+            }
+            $pagination = $pagination->nextPage();
+        } while ($page->hasNextPage());
+
+        return $results;
+    }
+}

--- a/src/Services/Videos/VideoSlugExtractor.php
+++ b/src/Services/Videos/VideoSlugExtractor.php
@@ -1,0 +1,48 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Kinescope\Services\Videos;
+
+use Kinescope\DTO\Video\VideoDTO;
+
+final class VideoSlugExtractor
+{
+    /** Extracts slug from HLS link, e.g. https://kinescope.io/{slug}/master.m3u8 */
+    public function fromHlsLink(string $hlsLink): ?string
+    {
+        if (preg_match('~kinescope\.io/([^/]+)/master\.m3u8~', $hlsLink, $m) === 1) {
+            return $m[1];
+        }
+
+        return null;
+    }
+
+    /** Extracts slug from embed code, e.g. <iframe src="https://kinescope.io/embed/{slug}" ...> */
+    public function fromEmbedCode(string $embedCode): ?string
+    {
+        if (preg_match('~kinescope\.io/embed/([^"\'\\s/]+)~', $embedCode, $m) === 1) {
+            return $m[1];
+        }
+
+        return null;
+    }
+
+    /** Tries hlsLink first, then embedCode. Returns null if neither is present/parseable. */
+    public function fromVideoDTO(VideoDTO $video): ?string
+    {
+        if ($video->hlsLink !== null) {
+            $slug = $this->fromHlsLink($video->hlsLink);
+
+            if ($slug !== null) {
+                return $slug;
+            }
+        }
+
+        if ($video->embedCode !== null) {
+            return $this->fromEmbedCode($video->embedCode);
+        }
+
+        return null;
+    }
+}

--- a/tests/Unit/Services/Videos/VideoFetcherTest.php
+++ b/tests/Unit/Services/Videos/VideoFetcherTest.php
@@ -1,0 +1,233 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Kinescope\Tests\Unit\Services\Videos;
+
+use Kinescope\Contracts\ApiClientInterface;
+use Kinescope\Enum\HttpMethod;
+use Kinescope\Services\Videos\VideoFetcher;
+use Kinescope\Services\Videos\Videos;
+use PHPUnit\Framework\TestCase;
+use RuntimeException;
+
+class VideoFetcherTest extends TestCase
+{
+    public function testFindByTitleReturnsSinglePageResults(): void
+    {
+        $apiClient = new class () implements ApiClientInterface {
+            public function get(string $endpoint, array $query = []): array
+            {
+                return [
+                    'data' => [
+                        self::makeRow('video-1', 'slug-aaa'),
+                        self::makeRow('video-2', 'slug-bbb'),
+                    ],
+                    'meta' => ['total' => 2, 'page' => 1, 'per_page' => 100, 'last_page' => 1],
+                ];
+            }
+
+            /** @return array<string, mixed> */
+            private static function makeRow(string $id, string $slug): array
+            {
+                return [
+                    'id' => $id,
+                    'title' => 'My Video',
+                    'status' => 'done',
+                    'duration' => 0,
+                    'hls_link' => "https://kinescope.io/{$slug}/master.m3u8",
+                    'created_at' => '2024-01-01T00:00:00Z',
+                    'updated_at' => '2024-01-01T00:00:00Z',
+                ];
+            }
+
+            public function post(string $endpoint, array $data = [], array $query = []): array
+            {
+                throw new RuntimeException('Not implemented.');
+            }
+
+            public function put(string $endpoint, array $data = [], array $query = []): array
+            {
+                throw new RuntimeException('Not implemented.');
+            }
+
+            public function patch(string $endpoint, array $data = [], array $query = []): array
+            {
+                throw new RuntimeException('Not implemented.');
+            }
+
+            public function delete(string $endpoint, array $query = []): array
+            {
+                throw new RuntimeException('Not implemented.');
+            }
+
+            public function request(HttpMethod $method, string $endpoint, array $options = []): array
+            {
+                throw new RuntimeException('Not implemented.');
+            }
+        };
+
+        $fetcher = new VideoFetcher(new Videos($apiClient));
+        $result = $fetcher->findByTitle('My Video');
+
+        $this->assertCount(2, $result);
+        $this->assertSame('video-1', $result[0]->id);
+        $this->assertSame('video-2', $result[1]->id);
+    }
+
+    public function testFindByTitleMergesMultiplePages(): void
+    {
+        $apiClient = new class () implements ApiClientInterface {
+            public function get(string $endpoint, array $query = []): array
+            {
+                $page = (int) ($query['page'] ?? 1);
+
+                if ($page === 1) {
+                    return [
+                        'data' => [
+                            ['id' => 'video-1', 'title' => 'Video', 'status' => 'done', 'duration' => 0, 'created_at' => '2024-01-01T00:00:00Z', 'updated_at' => '2024-01-01T00:00:00Z'],
+                        ],
+                        'meta' => ['total' => 2, 'page' => 1, 'per_page' => 100, 'last_page' => 2],
+                    ];
+                }
+
+                return [
+                    'data' => [
+                        ['id' => 'video-2', 'title' => 'Video', 'status' => 'done', 'duration' => 0, 'created_at' => '2024-01-01T00:00:00Z', 'updated_at' => '2024-01-01T00:00:00Z'],
+                    ],
+                    'meta' => ['total' => 2, 'page' => 2, 'per_page' => 100, 'last_page' => 2],
+                ];
+            }
+
+            public function post(string $endpoint, array $data = [], array $query = []): array
+            {
+                throw new RuntimeException('Not implemented.');
+            }
+
+            public function put(string $endpoint, array $data = [], array $query = []): array
+            {
+                throw new RuntimeException('Not implemented.');
+            }
+
+            public function patch(string $endpoint, array $data = [], array $query = []): array
+            {
+                throw new RuntimeException('Not implemented.');
+            }
+
+            public function delete(string $endpoint, array $query = []): array
+            {
+                throw new RuntimeException('Not implemented.');
+            }
+
+            public function request(HttpMethod $method, string $endpoint, array $options = []): array
+            {
+                throw new RuntimeException('Not implemented.');
+            }
+        };
+
+        $fetcher = new VideoFetcher(new Videos($apiClient));
+        $result = $fetcher->findByTitle('Video');
+
+        $this->assertCount(2, $result);
+        $this->assertSame('video-1', $result[0]->id);
+        $this->assertSame('video-2', $result[1]->id);
+    }
+
+    public function testFindByVideoSlugReturnsMatchingVideos(): void
+    {
+        $targetSlug = 'wDXNmhxAhnJeRtNjAVChzS';
+
+        $apiClient = new class ($targetSlug) implements ApiClientInterface {
+            public function __construct(private readonly string $targetSlug)
+            {
+            }
+
+            public function get(string $endpoint, array $query = []): array
+            {
+                return [
+                    'data' => [
+                        ['id' => 'video-1', 'title' => 'Match', 'status' => 'done', 'duration' => 0, 'hls_link' => "https://kinescope.io/{$this->targetSlug}/master.m3u8", 'created_at' => '2024-01-01T00:00:00Z', 'updated_at' => '2024-01-01T00:00:00Z'],
+                        ['id' => 'video-2', 'title' => 'Other', 'status' => 'done', 'duration' => 0, 'hls_link' => 'https://kinescope.io/otherSlug/master.m3u8', 'created_at' => '2024-01-01T00:00:00Z', 'updated_at' => '2024-01-01T00:00:00Z'],
+                    ],
+                    'meta' => ['total' => 2, 'page' => 1, 'per_page' => 100, 'last_page' => 1],
+                ];
+            }
+
+            public function post(string $endpoint, array $data = [], array $query = []): array
+            {
+                throw new RuntimeException('Not implemented.');
+            }
+
+            public function put(string $endpoint, array $data = [], array $query = []): array
+            {
+                throw new RuntimeException('Not implemented.');
+            }
+
+            public function patch(string $endpoint, array $data = [], array $query = []): array
+            {
+                throw new RuntimeException('Not implemented.');
+            }
+
+            public function delete(string $endpoint, array $query = []): array
+            {
+                throw new RuntimeException('Not implemented.');
+            }
+
+            public function request(HttpMethod $method, string $endpoint, array $options = []): array
+            {
+                throw new RuntimeException('Not implemented.');
+            }
+        };
+
+        $fetcher = new VideoFetcher(new Videos($apiClient));
+        $result = $fetcher->findByVideoSlug($targetSlug);
+
+        $this->assertCount(1, $result);
+        $this->assertSame('video-1', $result[0]->id);
+    }
+
+    public function testFindByVideoSlugReturnsEmptyArrayWhenNoMatch(): void
+    {
+        $apiClient = new class () implements ApiClientInterface {
+            public function get(string $endpoint, array $query = []): array
+            {
+                return [
+                    'data' => [
+                        ['id' => 'video-1', 'title' => 'Other', 'status' => 'done', 'duration' => 0, 'hls_link' => 'https://kinescope.io/someOtherSlug/master.m3u8', 'created_at' => '2024-01-01T00:00:00Z', 'updated_at' => '2024-01-01T00:00:00Z'],
+                    ],
+                    'meta' => ['total' => 1, 'page' => 1, 'per_page' => 100, 'last_page' => 1],
+                ];
+            }
+
+            public function post(string $endpoint, array $data = [], array $query = []): array
+            {
+                throw new RuntimeException('Not implemented.');
+            }
+
+            public function put(string $endpoint, array $data = [], array $query = []): array
+            {
+                throw new RuntimeException('Not implemented.');
+            }
+
+            public function patch(string $endpoint, array $data = [], array $query = []): array
+            {
+                throw new RuntimeException('Not implemented.');
+            }
+
+            public function delete(string $endpoint, array $query = []): array
+            {
+                throw new RuntimeException('Not implemented.');
+            }
+
+            public function request(HttpMethod $method, string $endpoint, array $options = []): array
+            {
+                throw new RuntimeException('Not implemented.');
+            }
+        };
+
+        $fetcher = new VideoFetcher(new Videos($apiClient));
+        $result = $fetcher->findByVideoSlug('nonExistentSlug');
+
+        $this->assertSame([], $result);
+    }
+}

--- a/tests/Unit/Services/Videos/VideoSlugExtractorTest.php
+++ b/tests/Unit/Services/Videos/VideoSlugExtractorTest.php
@@ -1,0 +1,127 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Kinescope\Tests\Unit\Services\Videos;
+
+use Kinescope\DTO\Video\VideoDTO;
+use Kinescope\Services\Videos\VideoSlugExtractor;
+use PHPUnit\Framework\TestCase;
+
+class VideoSlugExtractorTest extends TestCase
+{
+    private VideoSlugExtractor $extractor;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        $this->extractor = new VideoSlugExtractor();
+    }
+
+    public function testFromHlsLinkExtractsSlug(): void
+    {
+        $slug = $this->extractor->fromHlsLink('https://kinescope.io/wDXNmhxAhnJeRtNjAVChzS/master.m3u8');
+
+        $this->assertSame('wDXNmhxAhnJeRtNjAVChzS', $slug);
+    }
+
+    public function testFromHlsLinkReturnsNullForNonKinescopeUrl(): void
+    {
+        $slug = $this->extractor->fromHlsLink('https://example.com/video/master.m3u8');
+
+        $this->assertNull($slug);
+    }
+
+    public function testFromHlsLinkReturnsNullWhenMasterM3u8Absent(): void
+    {
+        $slug = $this->extractor->fromHlsLink('https://kinescope.io/wDXNmhxAhnJeRtNjAVChzS/playlist.m3u8');
+
+        $this->assertNull($slug);
+    }
+
+    public function testFromEmbedCodeExtractsSlug(): void
+    {
+        $embedCode = '<iframe src="https://kinescope.io/embed/wDXNmhxAhnJeRtNjAVChzS" allowfullscreen></iframe>';
+
+        $slug = $this->extractor->fromEmbedCode($embedCode);
+
+        $this->assertSame('wDXNmhxAhnJeRtNjAVChzS', $slug);
+    }
+
+    public function testFromEmbedCodeReturnsNullForNonKinescopeEmbed(): void
+    {
+        $embedCode = '<iframe src="https://youtube.com/embed/abc123" allowfullscreen></iframe>';
+
+        $slug = $this->extractor->fromEmbedCode($embedCode);
+
+        $this->assertNull($slug);
+    }
+
+    public function testFromVideoDtoExtractsSlugFromHlsLink(): void
+    {
+        $video = VideoDTO::fromArray([
+            'id' => 'video-1',
+            'title' => 'Test',
+            'status' => 'done',
+            'duration' => 0,
+            'hls_link' => 'https://kinescope.io/wDXNmhxAhnJeRtNjAVChzS/master.m3u8',
+            'created_at' => '2024-01-01T00:00:00Z',
+            'updated_at' => '2024-01-01T00:00:00Z',
+        ]);
+
+        $slug = $this->extractor->fromVideoDTO($video);
+
+        $this->assertSame('wDXNmhxAhnJeRtNjAVChzS', $slug);
+    }
+
+    public function testFromVideoDtoFallsBackToEmbedCode(): void
+    {
+        $video = VideoDTO::fromArray([
+            'id' => 'video-2',
+            'title' => 'Test',
+            'status' => 'done',
+            'duration' => 0,
+            'embed_code' => '<iframe src="https://kinescope.io/embed/embedSlug123" allowfullscreen></iframe>',
+            'created_at' => '2024-01-01T00:00:00Z',
+            'updated_at' => '2024-01-01T00:00:00Z',
+        ]);
+
+        $slug = $this->extractor->fromVideoDTO($video);
+
+        $this->assertSame('embedSlug123', $slug);
+    }
+
+    public function testFromVideoDtoPrioritizesHlsLinkOverEmbedCode(): void
+    {
+        $video = VideoDTO::fromArray([
+            'id' => 'video-3',
+            'title' => 'Test',
+            'status' => 'done',
+            'duration' => 0,
+            'hls_link' => 'https://kinescope.io/hlsSlug456/master.m3u8',
+            'embed_code' => '<iframe src="https://kinescope.io/embed/embedSlug789" allowfullscreen></iframe>',
+            'created_at' => '2024-01-01T00:00:00Z',
+            'updated_at' => '2024-01-01T00:00:00Z',
+        ]);
+
+        $slug = $this->extractor->fromVideoDTO($video);
+
+        $this->assertSame('hlsSlug456', $slug);
+    }
+
+    public function testFromVideoDtoReturnsNullWhenBothAbsent(): void
+    {
+        $video = VideoDTO::fromArray([
+            'id' => 'video-4',
+            'title' => 'Test',
+            'status' => 'done',
+            'duration' => 0,
+            'created_at' => '2024-01-01T00:00:00Z',
+            'updated_at' => '2024-01-01T00:00:00Z',
+        ]);
+
+        $slug = $this->extractor->fromVideoDTO($video);
+
+        $this->assertNull($slug);
+    }
+}


### PR DESCRIPTION
- Implemented `VideoSlugExtractor` for extracting slugs from HLS links, embed codes, and `VideoDTO`.
- Added `VideoFetcher` for auto-paginated video search by title or slug.
- Introduced unit tests for both services to ensure reliability and edge-case coverage.
- Updated changelog to document new features.