### PR TITLE
Add CLI agent skill for Kinescope SDK

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -40,6 +40,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 - `Kinescope\Services\Videos\InMemoryVideoSearch` for local reverse lookup over already loaded `VideoDTO` arrays by canonical embed URL or normalized title.
   - `byEmbedLink()` accepts only `https://kinescope.io/embed/{slug}` input and matches loaded DTOs through `VideoSlugExtractor`.
   - `byName()` uses deterministic normalized substring matching, not BM25, fuzzy search, stemming, or ranked full-text search.
+- `skills/kinescope-cli` AI agent skill distributed through `llm/skills` Composer metadata for agents that need to inspect Kinescope projects, folders, videos, assets, and statistics through the SDK CLI.
+  - Added `llm/skills` as a development dependency for local validation of the Composer skill distribution workflow.
 
 ### Fixed
 - `Retry-After` HTTP-date parsing now uses `Carbon\CarbonImmutable`, and 429 errors keep retry metadata on `RateLimitException`.

--- a/README.md
+++ b/README.md
@@ -133,6 +133,42 @@ vendor/bin/kinescope kinescope:statistics:show \
 
 List commands support `table` or deterministic `json` output. Resource show commands print pretty JSON. `kinescope:statistics:show` supports `table` and `json`; without a selector it reports account-wide statistics, or it can be scoped with exactly one of `--project-id` or `--folder-id`. Asset output exposes `video_stream_size`, `video_stream_size_mb`, and booleans such as `has_url`, `has_download_link`, and `downloadable`; raw signed CDN URLs and download links are not printed by default.
 
+## AI Agent Skill
+
+The package ships a `kinescope-cli` AI skill under `skills/kinescope-cli/` and declares it through `extra.skills.source` for [`llm/skills`](https://github.com/roxblnfk/skills). The skill helps coding agents use `vendor/bin/kinescope` safely: choose the current `kinescope:*` commands, prefer JSON for machine parsing, keep `KINESCOPE_API_KEY` out of output, and avoid exposing signed asset URLs.
+
+Install the Composer skill sync plugin in the consumer project:
+
+```bash
+composer require --dev llm/skills
+```
+
+Allow the plugin and trust this SDK as a skill donor:
+
+```json
+{
+  "config": {
+    "allow-plugins": {
+      "llm/skills": true
+    }
+  },
+  "extra": {
+    "skills": {
+      "trusted": ["mesilov/kinescope-php-sdk"],
+      "aliases": [".claude/skills"]
+    }
+  }
+}
+```
+
+Then sync the skill:
+
+```bash
+composer skills:update mesilov/kinescope-php-sdk --alias=.claude/skills
+```
+
+`llm/skills` writes the real skill directory to `.agents/skills/` by default, which works for Codex-style repo skills. The `--alias=.claude/skills` option mirrors the same target for Claude Code without keeping a second copy. If you already added `mesilov/kinescope-php-sdk` to `extra.skills.trusted`, you can omit the package argument and run `composer skills:update`.
+
 DTO timestamp properties such as `createdAt`, `updatedAt`, `deletedAt`, and `generatedAt` are `Carbon\CarbonImmutable` instances. `toArray()` keeps API field names such as `created_at` and serializes date values as ISO JSON strings, except that asset stream-size metadata is exported as `video_stream_size` to avoid implying a real downloaded file size.
 
 `AssetDTO::$videoStreamSize` maps raw API `assets[].file_size`. This is Kinescope stream metadata, not a guaranteed downloaded file size on disk. For download validation, progress after HTTP metadata is available, disk checks, and storage accounting, use HTTP `Content-Length`, transfer-reported bytes, bytes written, or final `filesize()`.

--- a/composer.json
+++ b/composer.json
@@ -33,6 +33,7 @@
         "fakerphp/faker": "^1.20",
         "friendsofphp/php-cs-fixer": "^3.0",
         "guzzlehttp/guzzle": "^7.10",
+        "llm/skills": "^1.1",
         "monolog/monolog": "^3.0",
         "nyholm/psr7": "^1.5",
         "php-http/mock-client": "^1.5",
@@ -58,10 +59,16 @@
         }
     },
     "bin": ["bin/kinescope"],
+    "extra": {
+        "skills": {
+            "source": "skills"
+        }
+    },
     "config": {
         "sort-packages": true,
         "allow-plugins": {
-            "php-http/discovery": true
+            "php-http/discovery": true,
+            "llm/skills": true
         }
     },
     "minimum-stability": "stable"

--- a/openspec/changes/add-kinescope-cli-agent-skill/.openspec.yaml
+++ b/openspec/changes/add-kinescope-cli-agent-skill/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-05-19

--- a/openspec/changes/add-kinescope-cli-agent-skill/design.md
+++ b/openspec/changes/add-kinescope-cli-agent-skill/design.md
@@ -1,0 +1,68 @@
+## Context
+
+The SDK exposes a Symfony Console executable at `vendor/bin/kinescope` with resource/action commands for read-only Kinescope inspection. Agents can already infer the command surface from README and OpenSpec, but that makes every consumer project repeat discovery and safety decisions.
+
+`llm/skills` is a Composer plugin that copies skill directories from installed donor packages into a project-local target, defaulting to `.agents/skills`. Donor packages opt in with `extra.skills.source`, and consumers control trust, aliases, and auto-sync from their root `composer.json`.
+
+## Goals / Non-Goals
+
+**Goals:**
+
+- Ship one `kinescope-cli` skill with the SDK package.
+- Declare the SDK as an `llm/skills` donor through Composer metadata.
+- Keep the skill usable by both Codex and Claude Code by using a plain `SKILL.md` structure and documenting `.agents/skills` plus `.claude/skills` aliasing.
+- Keep all CLI guidance aligned with the current `kinescope:<resource>:<action>` command surface.
+- Validate the skill as a package artifact without changing SDK runtime behavior.
+
+**Non-Goals:**
+
+- Do not reintroduce `video:info` or `kinescope:browse`.
+- Do not make `llm/skills` a runtime dependency of SDK consumers.
+- Do not copy generated skill mirrors into `.agents/skills` or `.claude/skills` in this repository.
+- Do not add a Codex plugin package in this change.
+
+## Decisions
+
+### Use `llm/skills` as the distribution path
+
+Add `llm/skills` to `require-dev` and allow it under Composer `config.allow-plugins`. The package is needed for local validation and documentation, but not for SDK runtime calls.
+
+Alternative considered: add `llm/skills` to `require`. Rejected because it would force a Composer plugin into every SDK installation even when the consumer only needs the PHP library.
+
+### Use `skills/` as the donor source
+
+Declare:
+
+```json
+{
+  "extra": {
+    "skills": {
+      "source": "skills"
+    }
+  }
+}
+```
+
+The plugin treats immediate subdirectories of that source as skills, so the distributed skill path is `skills/kinescope-cli/SKILL.md`.
+
+Alternative considered: `resources/skills`. Rejected for this package because the user explicitly wants a root `skills` distribution surface, and `llm/skills` supports that shape directly.
+
+### Let consumers create agent-specific paths
+
+Do not commit `.agents/skills` or `.claude/skills` mirrors. Consumer projects can run:
+
+```bash
+composer skills:update mesilov/kinescope-php-sdk --alias=.claude/skills
+```
+
+or configure `extra.skills.aliases`. This keeps one physical synced target and lets `llm/skills` manage symlink/junction mirrors.
+
+### Keep the skill instruction-only
+
+The first version should contain one `SKILL.md` and no scripts. The CLI already supplies deterministic JSON/table output; the skill's job is to choose the right command, protect secrets, prefer JSON for machine processing, and avoid printing signed asset links.
+
+## Risks / Trade-offs
+
+- `mesilov/*` is not in the current built-in trusted vendor list for `llm/skills` -> document that consumers must run the package explicitly or add `mesilov/kinescope-php-sdk` to `extra.skills.trusted`.
+- Claude Code projects may prefer `.claude/skills` -> document `--alias=.claude/skills` instead of duplicating files.
+- The skill can drift from the CLI -> validate its command list against README/OpenSpec and keep it updated when CLI commands change.

--- a/openspec/changes/add-kinescope-cli-agent-skill/proposal.md
+++ b/openspec/changes/add-kinescope-cli-agent-skill/proposal.md
@@ -1,0 +1,30 @@
+## Why
+
+The SDK now ships a dedicated `vendor/bin/kinescope` CLI with several resource/action commands, but AI agents still need to rediscover the command surface, safe output formats, and secret-handling rules from README and specs each time.
+
+Providing an agent skill with the SDK through `llm/skills` gives Codex and Claude Code a reusable, Composer-distributed workflow for using the CLI correctly and safely.
+
+## What Changes
+
+- Add `llm/skills` as a development dependency and allow the Composer plugin in this repository.
+- Add `extra.skills.source` so the SDK acts as a donor package for the Composer skill sync workflow.
+- Add a canonical `skills/kinescope-cli/` skill distributed with the SDK package.
+- Document the supported CLI command surface, credential rules, JSON/table selection, and asset-link sanitization guidance inside the skill.
+- Add README guidance showing how consumer projects sync the skill into `.agents/skills` and optionally alias it into `.claude/skills`.
+- Add validation coverage for the skill metadata and Composer donor configuration.
+- No SDK PHP API, CLI command behavior, or Composer binary contract changes.
+
+## Capabilities
+
+### New Capabilities
+- `kinescope-cli-agent-skill`: Distribution and discovery contract for the Kinescope CLI agent skill.
+
+### Modified Capabilities
+- None.
+
+## Impact
+
+- Affected files: `composer.json`, `skills/`, `README.md`, `CHANGELOG.md`, OpenSpec artifacts.
+- Affected public artifact: Composer-distributed agent skill documentation for the SDK CLI.
+- Affected runtime behavior: none.
+- Dependencies: development dependency on `llm/skills` Composer plugin.

--- a/openspec/changes/add-kinescope-cli-agent-skill/specs/kinescope-cli-agent-skill/spec.md
+++ b/openspec/changes/add-kinescope-cli-agent-skill/specs/kinescope-cli-agent-skill/spec.md
@@ -1,0 +1,43 @@
+## ADDED Requirements
+
+### Requirement: Declare SDK skill donor metadata
+The SDK package SHALL declare its Composer skill source so `llm/skills` can discover the distributed skill when the package is installed as a dependency.
+
+#### Scenario: Composer package exposes skills source
+- **WHEN** the SDK package is installed in a consumer project that uses `llm/skills`
+- **THEN** the package metadata exposes `extra.skills.source` with value `skills`
+- **AND** `skills/kinescope-cli/SKILL.md` exists inside the package
+
+### Requirement: Provide a Kinescope CLI agent skill
+The SDK package SHALL ship a `kinescope-cli` agent skill that helps coding agents use the SDK CLI safely and consistently.
+
+#### Scenario: Agent reads the skill
+- **WHEN** an agent opens `skills/kinescope-cli/SKILL.md`
+- **THEN** the file contains valid skill frontmatter with name `kinescope-cli`
+- **AND** the description covers Kinescope SDK CLI inspection tasks
+- **AND** the body documents command selection, credential handling, JSON/table output selection, and asset-link sanitization
+
+### Requirement: Keep skill guidance aligned with the current CLI
+The `kinescope-cli` skill SHALL describe the current `vendor/bin/kinescope` command surface and SHALL NOT instruct agents to use removed CLI commands.
+
+#### Scenario: Current commands are documented
+- **WHEN** the skill documents supported read-only commands
+- **THEN** it includes `kinescope:project:list`, `kinescope:project:show`, `kinescope:folder:list`, `kinescope:folder:show`, `kinescope:video:list`, `kinescope:video:show`, `kinescope:video:asset:list`, and `kinescope:statistics:show`
+- **AND** it does not present `video:info` or `kinescope:browse` as supported commands
+
+### Requirement: Document consumer sync workflow
+The SDK documentation SHALL explain how consumers sync the distributed skill through `llm/skills`.
+
+#### Scenario: Consumer wants Codex and Claude Code discovery
+- **WHEN** a consumer reads the SDK README
+- **THEN** the documentation shows that `llm/skills` syncs the SDK skill into `.agents/skills`
+- **AND** the documentation shows how to alias the same target into `.claude/skills`
+- **AND** the documentation states that `mesilov/kinescope-php-sdk` must be explicitly trusted or named during sync
+
+### Requirement: Keep skill distribution non-runtime
+The SDK SHALL keep `llm/skills` out of runtime dependencies.
+
+#### Scenario: Runtime dependencies are inspected
+- **WHEN** a consumer installs the SDK for PHP API usage
+- **THEN** `llm/skills` is not required by the SDK runtime dependency list
+- **AND** the package still declares the skill source for consumers that install the plugin separately

--- a/openspec/changes/add-kinescope-cli-agent-skill/tasks.md
+++ b/openspec/changes/add-kinescope-cli-agent-skill/tasks.md
@@ -1,0 +1,23 @@
+## 1. Composer distribution metadata
+- [x] 1.1 Add `llm/skills` as a development dependency.
+- [x] 1.2 Allow the `llm/skills` Composer plugin in repository configuration.
+- [x] 1.3 Declare `extra.skills.source` as `skills` in `composer.json`.
+
+## 2. Skill package
+- [x] 2.1 Add `skills/kinescope-cli/SKILL.md` with valid skill frontmatter.
+- [x] 2.2 Document the current `vendor/bin/kinescope` command surface.
+- [x] 2.3 Document safe credential handling and JSON/table output selection.
+- [x] 2.4 Document sanitized asset output and signed-link handling.
+- [x] 2.5 Avoid removed commands such as `video:info` and `kinescope:browse`.
+
+## 3. Documentation
+- [x] 3.1 Update README with `llm/skills` consumer sync instructions.
+- [x] 3.2 Document `.agents/skills` as the default target and `.claude/skills` as an alias.
+- [x] 3.3 Update CHANGELOG with the distributed agent skill and `llm/skills` dev dependency.
+
+## 4. Verification
+- [x] 4.1 Validate OpenSpec artifacts.
+- [x] 4.2 Validate skill frontmatter and required files.
+- [x] 4.3 Run `composer skills:show` / `composer skills:update --dry-run` checks where applicable.
+- [x] 4.4 Run `make test-unit`.
+- [x] 4.5 Run `make lint-all`.

--- a/skills/kinescope-cli/SKILL.md
+++ b/skills/kinescope-cli/SKILL.md
@@ -1,0 +1,105 @@
+---
+name: kinescope-cli
+description: Use when working with the Kinescope PHP SDK CLI for read-only account inspection, including listing or showing projects, folders, videos, video assets, and statistics through vendor/bin/kinescope or bin/kinescope. Helps agents choose current kinescope:* commands, handle KINESCOPE_API_KEY safely, prefer JSON for machine parsing, summarize table output for humans, and avoid exposing signed asset URLs or removed commands.
+---
+
+# Kinescope CLI
+
+Use the SDK CLI for read-only Kinescope inspection before reaching for raw API calls or PHP code.
+
+## Command Entry Point
+
+Prefer the installed package executable:
+
+```bash
+vendor/bin/kinescope <command>
+```
+
+When working inside this SDK repository before Composer bin proxies are available, use:
+
+```bash
+bin/kinescope <command>
+```
+
+If the command surface may have changed, inspect it first:
+
+```bash
+vendor/bin/kinescope list kinescope
+```
+
+Do not use removed commands: `video:info` and `kinescope:browse`.
+
+## Credentials
+
+Commands resolve credentials from `KINESCOPE_API_KEY` or `--api-key` / `-k`.
+
+- Prefer an existing `KINESCOPE_API_KEY` environment value.
+- Use `--api-key` only when the user explicitly provides a key for that run.
+- Never print, persist, commit, or echo the API key.
+- If credentials are missing, report that blocker and do not invent sample data.
+
+## Output Selection
+
+Use `--format=json` whenever you need to parse, compare, filter, count, or feed output to another tool.
+
+Use table output when the user wants a compact human-readable listing.
+
+When reporting results back, include the command shape you ran and a short summary of counts, ids, names, and scope. Avoid pasting large JSON payloads unless the user asks for raw output.
+
+## Current Commands
+
+Project commands:
+
+```bash
+vendor/bin/kinescope kinescope:project:list --format=json
+vendor/bin/kinescope kinescope:project:show <project-id>
+```
+
+Folder commands:
+
+```bash
+vendor/bin/kinescope kinescope:folder:list --project-id=<project-id> --format=json
+vendor/bin/kinescope kinescope:folder:show <folder-id> --project-id=<project-id>
+```
+
+Video commands:
+
+```bash
+vendor/bin/kinescope kinescope:video:list --project-id=<project-id> --format=json
+vendor/bin/kinescope kinescope:video:list --project-id=<project-id> --folder-id=<folder-id> --format=json
+vendor/bin/kinescope kinescope:video:show <video-id>
+```
+
+Asset commands:
+
+```bash
+vendor/bin/kinescope kinescope:video:list --project-id=<project-id> --include-assets --format=json
+vendor/bin/kinescope kinescope:video:asset:list <video-id> --format=json
+```
+
+Statistics commands:
+
+```bash
+vendor/bin/kinescope kinescope:statistics:show --format=json
+vendor/bin/kinescope kinescope:statistics:show --project-id=<project-id> --format=json
+vendor/bin/kinescope kinescope:statistics:show --folder-id=<folder-id> --format=json
+```
+
+`kinescope:statistics:show` accepts at most one scope selector: either `--project-id` or `--folder-id`.
+
+## Asset Safety
+
+Asset output is intentionally sanitized. It exposes fields such as `video_stream_size`, `video_stream_size_mb`, `has_url`, `has_download_link`, and `downloadable`.
+
+Do not try to expose raw signed CDN URLs or `download_link` values by default. If a direct API response ever includes signed URLs, treat them as ephemeral secrets and redact them from summaries unless the user explicitly asks for a raw payload.
+
+`video_stream_size` is Kinescope stream metadata, not a guaranteed final downloaded file size. For file-size verification, use HTTP `Content-Length`, transfer-reported bytes, bytes written, or final `filesize()`.
+
+## Error Handling
+
+If a command fails:
+
+- Preserve the command exit meaning: invalid input is a user/request issue, SDK/API failures are runtime issues.
+- Report the exact resource scope and selector involved.
+- For not-found responses, verify the project/folder/video id and parent-child relationship before proposing code changes.
+- For auth failures, ask for a valid API key path without printing the current key.

--- a/skills/kinescope-cli/agents/openai.yaml
+++ b/skills/kinescope-cli/agents/openai.yaml
@@ -1,0 +1,4 @@
+interface:
+  display_name: "Kinescope CLI"
+  short_description: "Use the Kinescope SDK CLI for safe read-only account inspection."
+  default_prompt: "Use the Kinescope CLI skill to inspect Kinescope projects, folders, videos, assets, or statistics."


### PR DESCRIPTION
Introduce `kinescope-cli` agent skill to the SDK, distributed via `llm/skills`. This skill facilitates safe and consistent use of the SDK's CLI, including command selection, credential handling, and output formatting. Updated documentation and added `llm/skills` as a development dependency for validation.