### PR TITLE
fix: move nyholm/psr7 from suggest to explicit dependency

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,75 +1,85 @@
 {
-    "name": "mesilov/kinescope-php-sdk",
-    "description": "Unofficial PHP SDK for Kinescope API - video management platform",
-    "keywords": ["kinescope", "video", "api", "sdk", "streaming", "live", "vod"],
-    "type": "library",
-    "license": "MIT",
-    "authors": [
-        {
-            "name": "Maksim Mesilov",
-            "email": "mesilov.maxim@gmail.com"
-        }
-    ],
-    "require": {
-        "php": ">=8.4",
-        "ext-curl": "*",
-        "ext-json": "*",
-        "ext-mbstring": "*",
-        "nesbot/carbon": "^3.0",
-        "php-http/discovery": "^1.14",
-        "php-http/httplug": "^2.2",
-        "psr/http-client": "^1.0",
-        "psr/http-factory": "^1.0",
-        "psr/http-message": "^1.0|^2.0",
-        "psr/log": "^1.1|^2.0|^3.0",
-        "symfony/console": "^8.0",
-        "symfony/dependency-injection": "^8.0",
-        "symfony/event-dispatcher": "^5.4|^6.0|^7.0|^8.0",
-        "symfony/filesystem": "^5.4|^6.0|^7.0|^8.0",
-        "symfony/mime": "^5.4|^6.0|^7.0|^8.0",
-        "symfony/uid": "^5.4|^6.0|^7.0|^8.0"
-    },
-    "require-dev": {
-        "fakerphp/faker": "^1.20",
-        "friendsofphp/php-cs-fixer": "^3.0",
-        "guzzlehttp/guzzle": "^7.10",
-        "llm/skills": "^1.1",
-        "monolog/monolog": "^3.0",
-        "nyholm/psr7": "^1.5",
-        "php-http/mock-client": "^1.5",
-        "phpstan/phpstan": "^2.0",
-        "phpstan/phpstan-phpunit": "^2.0",
-        "phpstan/phpstan-strict-rules": "^2.0",
-        "phpunit/phpunit": "^10.0|^11.0",
-        "rector/rector": "^2.0"
-    },
-    "suggest": {
-        "guzzlehttp/guzzle": "For HTTP client implementation",
-        "symfony/http-client": "For HTTP client implementation",
-        "nyholm/psr7": "For PSR-7/PSR-17 implementation"
-    },
-    "autoload": {
-        "psr-4": {
-            "Kinescope\\": "src/"
-        }
-    },
-    "autoload-dev": {
-        "psr-4": {
-            "Kinescope\\Tests\\": "tests/"
-        }
-    },
-    "bin": ["bin/kinescope"],
-    "extra": {
-        "skills": {
-            "source": "skills"
-        }
-    },
-    "config": {
-        "sort-packages": true,
-        "allow-plugins": {
-            "php-http/discovery": true,
-            "llm/skills": true
-        }
-    },
-    "minimum-stability": "stable"
+  "name": "mesilov/kinescope-php-sdk",
+  "description": "Unofficial PHP SDK for Kinescope API - video management platform",
+  "keywords": [
+    "kinescope",
+    "video",
+    "api",
+    "sdk",
+    "streaming",
+    "live",
+    "vod"
+  ],
+  "type": "library",
+  "license": "MIT",
+  "authors": [
+    {
+      "name": "Maksim Mesilov",
+      "email": "mesilov.maxim@gmail.com"
+    }
+  ],
+  "require": {
+    "php": ">=8.4",
+    "ext-curl": "*",
+    "ext-json": "*",
+    "ext-mbstring": "*",
+    "nesbot/carbon": "^3.0",
+    "php-http/discovery": "^1.14",
+    "php-http/httplug": "^2.2",
+    "psr/http-client": "^1.0",
+    "psr/http-factory": "^1.0",
+    "psr/http-message": "^1.0|^2.0",
+    "psr/log": "^1.1|^2.0|^3.0",
+    "symfony/console": "^8.0",
+    "symfony/dependency-injection": "^8.0",
+    "symfony/event-dispatcher": "^5.4|^6.0|^7.0|^8.0",
+    "symfony/filesystem": "^5.4|^6.0|^7.0|^8.0",
+    "symfony/mime": "^5.4|^6.0|^7.0|^8.0",
+    "symfony/uid": "^5.4|^6.0|^7.0|^8.0",
+    "nyholm/psr7": "^1.5"
+  },
+  "require-dev": {
+    "fakerphp/faker": "^1.20",
+    "friendsofphp/php-cs-fixer": "^3.0",
+    "guzzlehttp/guzzle": "^7.10",
+    "llm/skills": "^1.1",
+    "monolog/monolog": "^3.0",
+    "nyholm/psr7": "^1.5",
+    "php-http/mock-client": "^1.5",
+    "phpstan/phpstan": "^2.0",
+    "phpstan/phpstan-phpunit": "^2.0",
+    "phpstan/phpstan-strict-rules": "^2.0",
+    "phpunit/phpunit": "^10.0|^11.0",
+    "rector/rector": "^2.0"
+  },
+  "suggest": {
+    "guzzlehttp/guzzle": "For HTTP client implementation",
+    "symfony/http-client": "For HTTP client implementation"
+  },
+  "autoload": {
+    "psr-4": {
+      "Kinescope\\": "src/"
+    }
+  },
+  "autoload-dev": {
+    "psr-4": {
+      "Kinescope\\Tests\\": "tests/"
+    }
+  },
+  "bin": [
+    "bin/kinescope"
+  ],
+  "extra": {
+    "skills": {
+      "source": "skills"
+    }
+  },
+  "config": {
+    "sort-packages": true,
+    "allow-plugins": {
+      "php-http/discovery": true,
+      "llm/skills": true
+    }
+  },
+  "minimum-stability": "stable"
 }


### PR DESCRIPTION
## Summary

Move `nyholm/psr7` from `suggest` to `require` in `composer.json`.

## Why

`ApiClientFactory` uses `Psr18ClientDiscovery::find()` to auto-discover an HTTP client when none is explicitly provided. It also uses `Psr17FactoryDiscovery::findRequestFactory()` and `findStreamFactory()`. These discovery mechanisms return `nyholm/psr7` implementations, so the package is effectively required at runtime even though it's only listed in `suggest`.

This causes `composer install` to succeed while the SDK fails at runtime with a `Http\Discovery\Exception\StrategyUnavailableException` if the user hasn't installed a PSR-17/PSR-18 implementation separately.

## Fix

- Remove `nyholm/psr7` from `suggest`
- Add `nyholm/psr7: ^1.5` to `require` (same version as already in `require-dev`)

## Testing

`composer validate` passes.

Fixes issue #29.